### PR TITLE
Fix the command to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Dependencies
 
 ```bash
-npm run install
+npm install
 ```
 ## Test
 


### PR DESCRIPTION
`install` is a built-in command and not a script